### PR TITLE
run.sh: fix mix mode and organize results storage

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -65,6 +65,9 @@ function generate_plot()
                 plot=${outfile%.csv}.png
 	        echo "Generate plot for $outfile -> $plot"
                 gnuplot -e "set output '$plot'; FILENAME='$outfile'" $SETUP_DIR/plot-latency.gnu -p
+                echo Results stored in $dt/$outfile
+                mv $outfile $dt/
+                mv $plot $dt/
             fi
 	done
     fi
@@ -85,6 +88,9 @@ main() {
     APP_COMPONENT=$5
     MODE=$6
 
+    dt=$(date '+%d%m%Y%H%M%S');
+    dt="results/$dt"
+    mkdir -p $dt
 
     # Check for <BOARD>
     if [ "$2" = "icx" -o "$2" = "tgl" ]; then


### PR DESCRIPTION
In mix mode, listener1 would use af_packet socket while
listener2 user af_xdp socket.

Also rename the output file with the following format

af-<socket>-<mode>-listener<1/2>.csv

For example,
single mode
listener1: af-xdp-single-listener1.csv

dual mode
listener1: af-xdp-dual-listener1.csv
listener2: af-xdp-dual-listener2.csv

mix mode
listener1: af-packet-mix-listener1.csv
listener2: af-xdp-mix-listener2.csv

The results such as csv and png files
will be stored in results/<timestamp> folder.
The timestamp format is in %d%m%Y%H%M%S.